### PR TITLE
Over collateralized lending

### DIFF
--- a/extension/packages/nextjs/app/dashboard/_components/BorrowOperations.tsx
+++ b/extension/packages/nextjs/app/dashboard/_components/BorrowOperations.tsx
@@ -65,7 +65,7 @@ const BorrowOperations = () => {
               <RatioChange
                 user={address}
                 ethPrice={Number(formatEther(ethPrice || 0n))}
-                inputBorrowAmount={Number(borrowAmount)}
+                inputAmount={Number(borrowAmount)}
               />
             )}
           </label>
@@ -78,8 +78,15 @@ const BorrowOperations = () => {
         </div>
 
         <div className="form-control">
-          <label className="label">
+          <label className="label flex justify-between">
             <span className="label-text">Repay Debt</span>
+            {address && (
+              <RatioChange
+                user={address}
+                ethPrice={Number(formatEther(ethPrice || 0n))}
+                inputAmount={-Number(repayAmount)}
+              />
+            )}
           </label>
           <div className="flex gap-2 items-center">
             <IntegerInput value={repayAmount} onChange={setRepayAmount} placeholder="Amount" disableMultiplyBy1e18 />

--- a/extension/packages/nextjs/app/dashboard/_components/CollateralGraph.tsx
+++ b/extension/packages/nextjs/app/dashboard/_components/CollateralGraph.tsx
@@ -127,13 +127,21 @@ const CollateralGraph = () => {
     ];
   }, []);
 
+  // Filter the ratioData to keep only the last occurrence of each block number
+  const filteredRatioData = Object.values(
+    ratioData.reduce((acc, dataPoint) => {
+      acc[dataPoint.name] = dataPoint;
+      return acc;
+    }, {} as Record<number, DataPoint>)
+  );
+
   return (
     <div className="card bg-base-100 w-full shadow-xl indicator">
       <TooltipInfo top={3} right={3} infoText="This graph shows the total collateral/debt ratio over time" />
       <div className="card-body h-96 w-full">
         <h2 className="card-title">Total Collateral/Debt Ratio</h2>
         <ResponsiveContainer width="100%" height="100%">
-          <LineChart width={500} height={300} data={ratioData}>
+          <LineChart width={500} height={300} data={filteredRatioData}>
             <XAxis
               domain={["auto", "auto"]}
               dataKey="name"

--- a/extension/packages/nextjs/app/dashboard/_components/CollateralGraph.tsx
+++ b/extension/packages/nextjs/app/dashboard/_components/CollateralGraph.tsx
@@ -120,7 +120,7 @@ const CollateralGraph = () => {
       ...acc,
       {
         name: Number(event.blockNumber) || 0,
-        ratio: ratio && Number.isFinite(ratio) ? ratio : 1,
+        ratio: ratio && Number.isFinite(ratio) ? ratio * 100 : 100,
         collateral: collateralInEth,
         debt: debt,
       },
@@ -143,13 +143,18 @@ const CollateralGraph = () => {
             />
             <YAxis
               scale="log"
-              domain={[0.9, 1.5]}
-              tickFormatter={value => `${(value * 100).toFixed(0)}%`}
+              domain={[90, 150]}
+              tickFormatter={value => `${value.toFixed(0)}%`}
               stroke={strokeColor}
               tick={{ fill: strokeColor }}
             />
-            <Tooltip />
-            <ReferenceLine y={collateralRatio / 100} stroke="#ff4d4d" strokeDasharray="3 3" />
+            <Tooltip
+              itemStyle={{ color: "#82ca9d" }}
+              labelStyle={{ color: "#82ca9d" }}
+              formatter={(value: number) => [`${value.toFixed(3)}%`]}
+              labelFormatter={label => `Block ${label}`}
+            />
+            <ReferenceLine y={collateralRatio} stroke="#ff4d4d" strokeDasharray="3 3" />
             <Line type="monotone" dataKey="ratio" stroke="#82ca9d" dot={false} strokeWidth={2} />
           </LineChart>
         </ResponsiveContainer>

--- a/extension/packages/nextjs/app/dashboard/_components/CollateralOperations.tsx
+++ b/extension/packages/nextjs/app/dashboard/_components/CollateralOperations.tsx
@@ -68,7 +68,7 @@ const CollateralOperations = () => {
             <span className="label-text">Withdraw Collateral (ETH)</span>
           </label>
           <div className="flex gap-2 items-center">
-          <IntegerInput
+            <IntegerInput
               value={withdrawAmount}
               onChange={setWithdrawAmount}
               placeholder="Amount"

--- a/extension/packages/nextjs/app/dashboard/_components/RatioChange.tsx
+++ b/extension/packages/nextjs/app/dashboard/_components/RatioChange.tsx
@@ -6,10 +6,10 @@ import { calculatePositionRatio, getRatioColorClass } from "~~/utils/helpers";
 type UserPositionProps = {
   user: string;
   ethPrice: number;
-  inputBorrowAmount: number;
+  inputAmount: number;
 };
 
-const RatioChange = ({ user, ethPrice, inputBorrowAmount }: UserPositionProps) => {
+const RatioChange = ({ user, ethPrice, inputAmount }: UserPositionProps) => {
   const { data: userCollateral } = useScaffoldReadContract({
     contractName: "Lending",
     functionName: "s_userCollateral",
@@ -28,13 +28,18 @@ const RatioChange = ({ user, ethPrice, inputBorrowAmount }: UserPositionProps) =
       ? "N/A"
       : calculatePositionRatio(Number(formatEther(userCollateral || 0n)), borrowedAmount, ethPrice);
 
-  const newRatio = calculatePositionRatio(
-    Number(formatEther(userCollateral || 0n)),
-    borrowedAmount + inputBorrowAmount,
-    ethPrice,
-  );
+  const getNewRatio = (borrowedAmount: number, inputAmount: number) => {
+    const newBorrowAmount = borrowedAmount + inputAmount;
+    if (newBorrowAmount < 0) {
+      return <span className={getRatioColorClass(1)}>N/A</span>;
+    } else if (newBorrowAmount === 0) {
+      return <span className={getRatioColorClass(1000)}>∞</span>;
+    }
+    const newRatio = calculatePositionRatio(Number(formatEther(userCollateral || 0n)), newBorrowAmount, ethPrice);
+    return <span className={getRatioColorClass(newRatio)}>{newRatio.toFixed(2)}%</span>;
+  };
 
-  if (inputBorrowAmount <= 0) {
+  if (inputAmount === 0 || isNaN(inputAmount)) {
     return null;
   }
 
@@ -45,7 +50,7 @@ const RatioChange = ({ user, ethPrice, inputBorrowAmount }: UserPositionProps) =
       ) : (
         <span className={`${getRatioColorClass(ratio)} mx-0`}>{ratio.toFixed(2)}%</span>
       )}{" "}
-      → <span className={getRatioColorClass(newRatio)}>{newRatio.toFixed(2)}%</span>
+      → {getNewRatio(borrowedAmount, inputAmount)}
     </div>
   );
 };

--- a/extension/packages/nextjs/app/dashboard/_components/RatioChange.tsx
+++ b/extension/packages/nextjs/app/dashboard/_components/RatioChange.tsx
@@ -26,13 +26,13 @@ const RatioChange = ({ user, ethPrice, inputBorrowAmount }: UserPositionProps) =
   const ratio =
     borrowedAmount === 0
       ? "N/A"
-      : calculatePositionRatio(Number(formatEther(userCollateral || 0n)), borrowedAmount, ethPrice).toFixed(1);
+      : calculatePositionRatio(Number(formatEther(userCollateral || 0n)), borrowedAmount, ethPrice);
 
   const newRatio = calculatePositionRatio(
     Number(formatEther(userCollateral || 0n)),
     borrowedAmount + inputBorrowAmount,
     ethPrice,
-  ).toFixed(1);
+  );
 
   if (inputBorrowAmount <= 0) {
     return null;
@@ -43,9 +43,9 @@ const RatioChange = ({ user, ethPrice, inputBorrowAmount }: UserPositionProps) =
       {ratio === "N/A" ? (
         <span className={`${getRatioColorClass(1000)}`}>∞</span>
       ) : (
-        <span className={`${getRatioColorClass(ratio)} mx-0`}>{ratio}%</span>
+        <span className={`${getRatioColorClass(ratio)} mx-0`}>{ratio.toFixed(2)}%</span>
       )}{" "}
-      → <span className={getRatioColorClass(newRatio)}>{newRatio}%</span>
+      → <span className={getRatioColorClass(newRatio)}>{newRatio.toFixed(2)}%</span>
     </div>
   );
 };


### PR DESCRIPTION
Here is the frontend fixes related to Rinat's comments.

His first comment: https://github.com/scaffold-eth/se-2-challenges/pull/282#pullrequestreview-2750788698
I think everything is correct and replied here: https://github.com/scaffold-eth/se-2-challenges/pull/282#issuecomment-2797833510 . What do you think?

https://github.com/scaffold-eth/se-2-challenges/pull/282#discussion_r2033682309
In tooltip, it also will display in percent:
<img width="630" alt="image" src="https://github.com/user-attachments/assets/797310e0-821e-4684-83f8-a68eaeac913e" />


https://github.com/scaffold-eth/se-2-challenges/pull/282#discussion_r2033684642
Added Ratio change display in Repay debt as well.
<img width="426" alt="image" src="https://github.com/user-attachments/assets/6e629102-9350-499d-aaf1-7bb4237fa473" />
Here are some tests:
<img width="426" alt="image" src="https://github.com/user-attachments/assets/8697d1ee-a1d9-4673-bd22-29f40a727721" />
<img width="444" alt="image" src="https://github.com/user-attachments/assets/14d6cd57-4b9e-4358-ae3d-cbd6895bbf3e" />
<img width="431" alt="image" src="https://github.com/user-attachments/assets/d483c25d-b61b-4d8e-bea5-d69e3060e490" />


https://github.com/scaffold-eth/se-2-challenges/pull/282#discussion_r2033685839
Good point. That was happening because we were checking the value after rounding. Now, we check it before rounding.
<img width="437" alt="image" src="https://github.com/user-attachments/assets/4b19f003-4750-4263-87a4-cd9e5702ccf9" />
<img width="424" alt="image" src="https://github.com/user-attachments/assets/a51c7f55-63da-464c-ade7-54357ef358cb" />


https://github.com/scaffold-eth/se-2-challenges/pull/282#issuecomment-2790425463
Leveraging occurs within a single block, so I filter all the events and retain only the last value from that block.
<img width="645" alt="image" src="https://github.com/user-attachments/assets/627ee2b8-4b83-4f46-ad74-5313106d4856" />
