### PR TITLE
fix: based on the feedback

### DIFF
--- a/extension/packages/nextjs/app/_components/Modals/TokenSwapModal.tsx
+++ b/extension/packages/nextjs/app/_components/Modals/TokenSwapModal.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import TooltipInfo from "../TooltipInfo";
 import { Address, parseEther } from "viem";
 import { ArrowDownIcon, ArrowsRightLeftIcon } from "@heroicons/react/24/outline";
 import { Balance, IntegerInput } from "~~/components/scaffold-eth";
@@ -108,9 +109,12 @@ export const TokenSwapModal = ({ tokenBalance, connectedAddress, ETHprice, modal
           {/* dummy input to capture event onclick on modal box */}
           <input className="h-0 w-0 absolute top-0 left-0" />
           <h3 className="text-xl font-bold mb-3">Simple Swap</h3>
-          <label htmlFor={`${modalId}`} className="btn btn-ghost btn-sm btn-circle absolute right-3 top-3">
-            ✕
-          </label>
+          <div className="absolute top-3 right-3 flex items-center space-x-2">
+            <TooltipInfo top={0} right={0} infoText={`Here you can swap ${tokenName} for ETH and vice versa`} />
+            <label htmlFor={`${modalId}`} className="btn btn-ghost btn-sm btn-circle">
+              ✕
+            </label>
+          </div>
           <div className="space-y-3">
             <div className="flex space-x-4">
               <div className="flex flex-col">

--- a/extension/packages/nextjs/app/_components/Modals/TokenTransferModal.tsx
+++ b/extension/packages/nextjs/app/_components/Modals/TokenTransferModal.tsx
@@ -4,6 +4,7 @@ import { BanknotesIcon } from "@heroicons/react/24/outline";
 import { Address, AddressInput, IntegerInput } from "~~/components/scaffold-eth";
 import { useScaffoldWriteContract } from "~~/hooks/scaffold-eth";
 import { tokenName } from "~~/utils/constant";
+import TooltipInfo from "../TooltipInfo";
 
 type TokenTransferModalProps = {
   tokenBalance: string;
@@ -43,9 +44,12 @@ export const TokenTransferModal = ({ tokenBalance, connectedAddress, modalId }: 
           {/* dummy input to capture event onclick on modal box */}
           <input className="h-0 w-0 absolute top-0 left-0" />
           <h3 className="text-xl font-bold mb-3">Send {tokenName}</h3>
-          <label htmlFor={`${modalId}`} className="btn btn-ghost btn-sm btn-circle absolute right-3 top-3">
-            ✕
-          </label>
+          <div className="absolute top-3 right-3 flex items-center space-x-2">
+            <TooltipInfo top={0} right={0} infoText={`Here you can send ${tokenName} to another address`} />
+            <label htmlFor={`${modalId}`} className="btn btn-ghost btn-sm btn-circle">
+              ✕
+            </label>
+          </div>
           <div className="space-y-2">
             <div className="flex space-x-4">
               <div>

--- a/extension/packages/nextjs/app/_components/PriceGraph.tsx
+++ b/extension/packages/nextjs/app/_components/PriceGraph.tsx
@@ -85,7 +85,7 @@ const PriceGraph = () => {
     return [
       ...acc,
       {
-        blockNumber: Number(event.blockNumber) || 0,
+        blockNumber: Number(event?.blockNumber) || 0,
         price: price && Number.isFinite(price) ? price : prevPrice,
         borrowRate: borrowRate >= 0 && Number.isFinite(borrowRate) ? borrowRate : prevBorrowRate,
         savingsRate: savingsRate >= 0 && Number.isFinite(savingsRate) ? savingsRate : prevSavingsRate,
@@ -177,9 +177,7 @@ const PriceGraph = () => {
                 verticalAlign="top"
                 wrapperStyle={{ paddingBottom: 10 }}
                 formatter={value => <span style={{ color: strokeColor }}>{value}</span>}
-                payload={showRates ? undefined : [
-                  { value: "Price", type: "line", color: yellowColor }
-                ]}
+                payload={showRates ? undefined : [{ value: "Price", type: "line", color: yellowColor }]}
               />
             </LineChart>
           </ResponsiveContainer>

--- a/extension/packages/nextjs/app/_components/PriceGraph.tsx
+++ b/extension/packages/nextjs/app/_components/PriceGraph.tsx
@@ -133,17 +133,16 @@ const PriceGraph = () => {
                 tick={{ fill: strokeColor, fontSize: 12 }}
                 label={{ value: "Price", angle: -90, position: "insideLeft", fill: strokeColor, offset: -10 }}
               />
-              {showRates && (
-                <YAxis
-                  yAxisId="right"
-                  orientation="right"
-                  scale="linear"
-                  domain={[(dataMin: number) => dataMin - 0.5, (dataMax: number) => dataMax + 0.5]}
-                  stroke={strokeColor}
-                  tick={{ fill: strokeColor, fontSize: 12 }}
-                  label={{ value: "Rates (%)", angle: 90, position: "insideRight", fill: strokeColor, dy: 15, dx: -15 }}
-                />
-              )}
+              <YAxis
+                yAxisId="right"
+                orientation="right"
+                scale="linear"
+                domain={[(dataMin: number) => dataMin - 0.5, (dataMax: number) => dataMax + 0.5]}
+                stroke={strokeColor}
+                tick={{ fill: strokeColor, fontSize: 12 }}
+                label={{ value: "Rates (%)", angle: 90, position: "insideRight", fill: strokeColor, dy: 15, dx: -15 }}
+                hide={!showRates}
+              />
               <ReferenceLine yAxisId="left" y={1.0} stroke="#71717b" strokeDasharray="5 5" strokeWidth={2} />
               <Line
                 yAxisId="left"
@@ -154,32 +153,33 @@ const PriceGraph = () => {
                 strokeWidth={2}
                 name="Price"
               />
-              {showRates && (
-                <>
-                  <Line
-                    yAxisId="right"
-                    type="monotone"
-                    dataKey="borrowRate"
-                    stroke={redColor}
-                    dot={false}
-                    strokeWidth={2}
-                    name="Borrow Rate"
-                  />
-                  <Line
-                    yAxisId="right"
-                    type="monotone"
-                    dataKey="savingsRate"
-                    stroke={greenColor}
-                    dot={false}
-                    strokeWidth={2}
-                    name="Savings Rate"
-                  />
-                </>
-              )}
+              <Line
+                yAxisId="right"
+                type="monotone"
+                dataKey="savingsRate"
+                stroke={greenColor}
+                dot={false}
+                strokeWidth={2}
+                name="Savings Rate"
+                hide={!showRates}
+              />
+              <Line
+                yAxisId="right"
+                type="monotone"
+                dataKey="borrowRate"
+                stroke={redColor}
+                dot={false}
+                strokeWidth={2}
+                name="Borrow Rate"
+                hide={!showRates}
+              />
               <Legend
                 verticalAlign="top"
                 wrapperStyle={{ paddingBottom: 10 }}
                 formatter={value => <span style={{ color: strokeColor }}>{value}</span>}
+                payload={showRates ? undefined : [
+                  { value: "Price", type: "line", color: yellowColor }
+                ]}
               />
             </LineChart>
           </ResponsiveContainer>

--- a/extension/packages/nextjs/app/_components/SideButtons.tsx
+++ b/extension/packages/nextjs/app/_components/SideButtons.tsx
@@ -86,7 +86,7 @@ const SideButtons: React.FC = () => {
 
   return (
     <div
-      className="absolute top-[120px] right-0 bg-base-100 w-fit border-base-300 border shadow-md rounded-xl z-5"
+      className="absolute top-[120px] right-0 bg-base-100 w-fit border-base-300 border shadow-md rounded-xl"
       onMouseEnter={handleContainerEnter}
       onMouseLeave={handleContainerLeave}
     >
@@ -113,7 +113,7 @@ const SideButtons: React.FC = () => {
 
         {/* Hover Windows */}
         <div
-          className={`absolute top-1/2 -translate-y-1/2 right-full mr-4 transition-all duration-300 z-10 ease-in-out ${hoveredButton ? "opacity-100 translate-x-0" : "opacity-0 -translate-x-4 pointer-events-none"}`}
+          className={`absolute top-1/2 -translate-y-1/2 right-full mr-4 transition-all duration-300 z-20 ease-in-out ${hoveredButton ? "opacity-100 translate-x-0" : "opacity-0 -translate-x-4 pointer-events-none"}`}
           onMouseEnter={handleContainerEnter}
           onMouseLeave={handleContainerLeave}
         >

--- a/extension/packages/nextjs/app/_components/StakersTable.tsx
+++ b/extension/packages/nextjs/app/_components/StakersTable.tsx
@@ -13,7 +13,7 @@ const StakerRow = ({ staker, connectedAddress }: { staker: string; connectedAddr
   });
 
   return (
-    <tr key={staker} className={`${connectedAddress === staker ? "bg-blue-100 dark:bg-blue-900" : ""}`}>
+    <tr key={staker} className={`${connectedAddress === staker ? "bg-primary" : ""}`}>
       <td>
         <AddressBlock address={staker} disableAddressLink format="short" size="sm" />
       </td>

--- a/extension/packages/nextjs/app/_components/SupplyGraph.tsx
+++ b/extension/packages/nextjs/app/_components/SupplyGraph.tsx
@@ -14,6 +14,7 @@ import {
 } from "recharts";
 import { formatEther } from "viem";
 import { useScaffoldEventHistory, useScaffoldReadContract } from "~~/hooks/scaffold-eth";
+import { formatDisplayValue } from "~~/utils/helpers";
 
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 const PURPLE_COLOR = "#8884d8";
@@ -29,16 +30,6 @@ const calculateDexSwapAmounts = (event: any) => {
     sent: isEthToMyUSD ? Number(formatEther(outputAmount || 0n)) : 0,
     received: !isEthToMyUSD ? Number(formatEther(inputAmount || 0n)) : 0,
   };
-};
-
-const formatDisplayValue = (value: number) => {
-  if (value > 1000000) {
-    return `${(value / 1000000).toFixed(2)}M`;
-  }
-  if (value > 1000) {
-    return `${(value / 1000).toFixed(2)}k`;
-  }
-  return value.toFixed(2);
 };
 
 const CustomTooltip = ({ active, payload, label }: TooltipProps<number, string>) => {

--- a/extension/packages/nextjs/app/_components/UserPosition.tsx
+++ b/extension/packages/nextjs/app/_components/UserPosition.tsx
@@ -3,7 +3,7 @@ import { formatEther, parseEther } from "viem";
 import { Address as AddressBlock } from "~~/components/scaffold-eth";
 import { useDeployedContractInfo, useScaffoldReadContract, useScaffoldWriteContract } from "~~/hooks/scaffold-eth";
 import { collateralRatio, tokenName } from "~~/utils/constant";
-import { calculatePositionRatio, getRatioColorClass } from "~~/utils/helpers";
+import { calculatePositionRatio, formatDisplayValue, getRatioColorClass } from "~~/utils/helpers";
 import { notification } from "~~/utils/scaffold-eth";
 
 type UserPositionProps = {
@@ -95,7 +95,22 @@ const UserPosition = ({ user, ethPrice, connectedAddress }: UserPositionProps) =
       <td>
         <AddressBlock address={user} disableAddressLink format="short" size="sm" />
       </td>
-      <td>{Number(formatEther(userMinted || 0n)).toFixed(2)}</td>
+      <td>
+        <div
+          className="tooltip tooltip-primary"
+          data-tip={`${Number(formatEther(userCollateral || 0n)).toFixed(2)} ETH`}
+        >
+          {formatDisplayValue(Number(formatEther(userCollateral || 0n)))}
+        </div>
+      </td>
+      <td>
+        <div
+          className="tooltip tooltip-primary"
+          data-tip={`${Number(formatEther(userMinted || 0n)).toFixed(2)} ${tokenName}`}
+        >
+          {formatDisplayValue(Number(formatEther(userMinted || 0n)))}
+        </div>
+      </td>
       <td className={getRatioColorClass(ratio)}>{formattedRatio === "N/A" ? "N/A" : `${formattedRatio}%`}</td>
       <td className="text-center p-1">
         <button onClick={liquidatePosition} disabled={isPositionSafe} className="btn btn-xs btn-ghost">

--- a/extension/packages/nextjs/app/_components/UserPosition.tsx
+++ b/extension/packages/nextjs/app/_components/UserPosition.tsx
@@ -91,7 +91,7 @@ const UserPosition = ({ user, ethPrice, connectedAddress }: UserPositionProps) =
   if (userCollateral === parseEther("10000000000000000000")) return null;
 
   return (
-    <tr key={user} className={`${connectedAddress === user ? "bg-blue-100 dark:bg-blue-900" : ""}`}>
+    <tr key={user} className={`${connectedAddress === user ? "bg-primary" : ""}`}>
       <td>
         <AddressBlock address={user} disableAddressLink format="short" size="sm" />
       </td>

--- a/extension/packages/nextjs/app/_components/UserPositionsTable.tsx
+++ b/extension/packages/nextjs/app/_components/UserPositionsTable.tsx
@@ -29,6 +29,7 @@ const UserPositionsTable = () => {
     setUsers(prevUsers => {
       const uniqueUsers = new Set([...prevUsers]);
       events
+        .filter(event => event && event.args)
         .map(event => event.args.user)
         .filter((user): user is string => !!user)
         .forEach(user => uniqueUsers.add(user));

--- a/extension/packages/nextjs/app/_components/UserPositionsTable.tsx
+++ b/extension/packages/nextjs/app/_components/UserPositionsTable.tsx
@@ -41,14 +41,15 @@ const UserPositionsTable = () => {
       <TooltipInfo
         top={3}
         right={3}
-        infoText="Monitor all MyUSDEngine positions and liquidate undercollateralized accounts"
+        infoText="Monitor all MyUSDEngine positions and liquidate undercollateralized accounts. Hover over the values (Collateral and Debt) to see the exact amounts."
       />
       <div className="overflow-x-auto">
         <table className="table">
           <thead>
             <tr>
               <th>Address</th>
-              <th>Debt ({tokenName})</th>
+              <th>Collateral</th>
+              <th>Debt</th>
               <th>Ratio</th>
               <th></th>
             </tr>
@@ -58,6 +59,9 @@ const UserPositionsTable = () => {
               <tr key={"skeleton"}>
                 <td>
                   <div className="skeleton w-36 h-6"></div>
+                </td>
+                <td>
+                  <div className="skeleton w-16 h-6"></div>
                 </td>
                 <td>
                   <div className="skeleton w-16 h-6"></div>

--- a/extension/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx.args.mjs
+++ b/extension/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx.args.mjs
@@ -1,1 +1,10 @@
-export const globalClassNames = "font-space-grotesk";
+export const providerImports = `
+import { Space_Grotesk } from "next/font/google";
+const spaceGrotesk = Space_Grotesk({
+  subsets: ["latin"],
+  variable: "--font-space-grotesk",
+});
+`;
+
+
+export const globalClassNames = "${spaceGrotesk.variable} font-space-grotesk";

--- a/extension/packages/nextjs/styles/globals.css.args.mjs
+++ b/extension/packages/nextjs/styles/globals.css.args.mjs
@@ -1,1 +1,52 @@
-export const globalImports = '@import url("https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&display=swap");';
+export const globalImports =
+  '@import url("https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&display=swap");';
+
+export const postContent = `
+@plugin "daisyui/theme" {
+  name: "light";
+  --color-primary: #C8F5FF;
+  --color-primary-content: #026262;
+  --color-secondary: #89d7e9;
+  --color-secondary-content: #088484;
+  --color-accent: #026262;
+  --color-accent-content: #E9FBFF;
+  --color-neutral: #088484;
+  --color-neutral-content: #F0FCFF;
+  --color-base-100: #F0FCFF;
+  --color-base-200: #E1FAFF;
+  --color-base-300: #C8F5FF;
+  --color-base-content: #088484;
+  --color-info: #026262;
+  --color-success: #34eeb6;
+  --color-warning: #ffcf72;
+  --color-error: #ff8863;
+  --radius-field: 9999rem;
+  --radius-box: 1rem;
+  --tt-tailw: 6px;
+}
+@plugin "daisyui/theme" {
+  name: "dark";
+  --color-primary: #026262;
+  --color-primary-content: #C8F5FF;
+  --color-secondary: #107575;
+  --color-secondary-content: #E9FBFF;
+  --color-accent: #C8F5FF;
+  --color-accent-content: #088484;
+  --color-neutral: #E9FBFF;
+  --color-neutral-content: #11ACAC;
+  --color-base-100: #11ACAC;
+  --color-base-200: #088484;
+  --color-base-300: #026262;
+  --color-base-content: #E9FBFF;
+  --color-info: #C8F5FF;
+  --color-success: #34eeb6;
+  --color-warning: #ffcf72;
+  --color-error: #ff8863;
+  --radius-field: 9999rem;
+  --radius-box: 1rem;
+  --tt-tailw: 6px;
+  --tt-bg: var(--color-primary);
+}
+@theme inline: {
+  --font-space-grotesk: var(--font-space-grotesk);
+}`;

--- a/extension/packages/nextjs/utils/helpers.ts
+++ b/extension/packages/nextjs/utils/helpers.ts
@@ -12,3 +12,13 @@ export function calculatePositionRatio(userCollateral: number, mintedAmount: num
   if (mintedAmount === 0) return Number.MAX_SAFE_INTEGER; // Return max if no tokens are minted
   return (collateralValue / mintedAmount) * 100; // Calculate position ratio
 }
+
+export const formatDisplayValue = (value: number) => {
+  if (value > 1000000) {
+    return `${(value / 1000000).toFixed(2)}M`;
+  }
+  if (value > 1000) {
+    return `${(value / 1000).toFixed(2)}k`;
+  }
+  return value.toFixed(2);
+};


### PR DESCRIPTION
- fix with displaying the right y-axis and borrow, saving lines. use hide property
- fix z-index for the sidebuttons (it will not be highlighted when modals are open) and for the appearing containers
- update row color in both tables
- add tooltip to display all circulating, staked and total supply
- add info for swap and transfer modals
- update theme and font